### PR TITLE
Bump akka version to 2.4.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,9 +21,9 @@ resolvers += Resolver.mavenLocal
 checksums in update := Nil
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-http-experimental" % "2.0.3", 
-  "com.typesafe.akka" %% "akka-http-testkit-experimental" % "2.0.3" % "test",
-  "com.typesafe.akka" %% "akka-http-spray-json-experimental" % "2.0.3",
+  "com.typesafe.akka" %% "akka-http-experimental" % "2.4.6",
+  "com.typesafe.akka" %% "akka-http-testkit" % "2.4.6" % "test",
+  "com.typesafe.akka" %% "akka-http-spray-json-experimental" % "2.4.6",
   "io.swagger" %% "swagger-scala-module" % "1.0.1",
   "io.swagger" % "swagger-core" % "1.5.6",
   "io.swagger" % "swagger-annotations" % "1.5.6",


### PR DESCRIPTION
Sometime between akka versions `2.4.4` and `2.4.6` started getting `NoSuchMethodError` for `com.github.swagger.akka.SwaggerHttpService.segmentStringToPathMatcher`.

Bumping the version verified to work with both `2.4.4` and `2.4.6` akka versions. I'm not sure how this might effect applications with earlier versions of akka.

(Also, thanks for the project!!)

Stack trace:
```
contractWeb[ERROR] java.lang.NoSuchMethodError: com.github.swagger.akka.SwaggerHttpService.segmentStringToPathMatcher(Ljava/lang/String;)Lakka/http/scaladsl/server/PathMatcher;
contractWeb[ERROR] 	at com.github.swagger.akka.SwaggerHttpService$$anonfun$1.apply(SwaggerHttpService.scala:72)
contractWeb[ERROR] 	at com.github.swagger.akka.SwaggerHttpService$$anonfun$1.apply(SwaggerHttpService.scala:72)
contractWeb[ERROR] 	at akka.http.scaladsl.server.Directive$$anonfun$addByNameNullaryApply$1$$anonfun$apply$13.apply(Directive.scala:136)
contractWeb[ERROR] 	at akka.http.scaladsl.server.Directive$$anonfun$addByNameNullaryApply$1$$anonfun$apply$13.apply(Directive.scala:136)
contractWeb [ERROR] [05/25/2016 10:47:48.296] [default-akka.actor.default-dispatcher-4] [akka.actor.ActorSystemImpl(default)] Uncaught error from thread [default-akka.actor.default-dispatcher-4] shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled
contractWeb java.lang.NoSuchMethodError: com.github.swagger.akka.SwaggerHttpService.segmentStringToPathMatcher(Ljava/lang/String;)Lakka/http/scaladsl/server/PathMatcher;
contractWeb 	at com.github.swagger.akka.SwaggerHttpService$$anonfun$1.apply(SwaggerHttpService.scala:72)
contractWeb 	at com.github.swagger.akka.SwaggerHttpService$$anonfun$1.apply(SwaggerHttpService.scala:72)
contractWeb 	at akka.http.scaladsl.server.Directive$$anonfun$addByNameNullaryApply$1$$anonfun$apply$13.apply(Directive.scala:136)
contractWeb 	at akka.http.scaladsl.server.Directive$$anonfun$addByNameNullaryApply$1$$anonfun$apply$13.apply(Directive.scala:136)
contractWeb 	at akka.http.scaladsl.server.ConjunctionMagnet$$anon$2$$anonfun$apply$14$$anonfun$apply$15$$anonfun$apply$16.apply(Directive.scala:164)
contractWeb 	at akka.http.scaladsl.server.ConjunctionMagnet$$anon$2$$anonfun$apply$14$$anonfun$apply$15$$anonfun$apply$16.apply(Directive.scala:164)
contractWeb 	at akka.http.scaladsl.server.directives.BasicDirectives$$anonfun$mapRouteResult$1$$anonfun$apply$3.apply(BasicDirectives.scala:52)
contractWeb 	at akka.http.scaladsl.server.directives.BasicDirectives$$anonfun$mapRouteResult$1$$anonfun$apply$3.apply(BasicDirectives.scala:52)
contractWeb 	at akka.http.scaladsl.server.directives.BasicDirectives$$anonfun$textract$1$$anonfun$apply$5.apply(BasicDirectives.scala:145)
contractWeb 	at akka.http.scaladsl.server.directives.BasicDirectives$$anonfun$textract$1$$anonfun$apply$5.apply(BasicDirectives.scala:145)
contractWeb 	at akka.http.scaladsl.server.Directive$$anonfun$recover$1$$anonfun$apply$8$$anonfun$apply$11.apply(Directive.scala:96)
contractWeb 	at akka.http.scaladsl.server.Directive$$anonfun$recover$1$$anonfun$apply$8$$anonfun$apply$11.apply(Directive.scala:95)
contractWeb 	at akka.http.scaladsl.util.FastFuture$.akka$http$scaladsl$util$FastFuture$$strictTransform$1(FastFuture.scala:41)
contractWeb 	at akka.http.scaladsl.util.FastFuture$.transformWith$extension1(FastFuture.scala:45)
contractWeb 	at akka.http.scaladsl.util.FastFuture$.flatMap$extension(FastFuture.scala:26)
contractWeb 	at akka.http.scaladsl.server.Directive$$anonfun$recover$1$$anonfun$apply$8.apply(Directive.scala:95)
contractWeb 	at akka.http.scaladsl.server.Directive$$anonfun$recover$1$$anonfun$apply$8.apply(Directive.scala:92)
contractWeb 	at akka.http.scaladsl.server.RouteConcatenation$RouteWithConcatenation$$anonfun$$tilde$1$$anonfun$apply$1.apply(RouteConcatenation.scala:47)
contractWeb 	at akka.http.scaladsl.server.RouteConcatenation$RouteWithConcatenation$$anonfun$$tilde$1$$anonfun$apply$1.apply(RouteConcatenation.scala:44)
contractWeb 	at akka.http.scaladsl.util.FastFuture$.akka$http$scaladsl$util$FastFuture$$strictTransform$1(FastFuture.scala:41)
contractWeb 	at akka.http.scaladsl.util.FastFuture$.transformWith$extension1(FastFuture.scala:45)
contractWeb 	at akka.http.scaladsl.util.FastFuture$.flatMap$extension(FastFuture.scala:26)
contractWeb 	at akka.http.scaladsl.server.RouteConcatenation$RouteWithConcatenation$$anonfun$$tilde$1.apply(RouteConcatenation.scala:44)
```