### PR TITLE
Update jackson, json4s and akka references

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,17 +21,28 @@ resolvers += Resolver.mavenLocal
 checksums in update := Nil
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-http-experimental" % "2.4.6", 
-  "com.typesafe.akka" %% "akka-http-testkit" % "2.4.6" % "test",
-  "com.typesafe.akka" %% "akka-http-spray-json-experimental" % "2.4.6",
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.7.5",
+  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.7.5",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.5",
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml" % "2.7.5",
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % "2.7.5",
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % "2.7.5",
+  "com.fasterxml.jackson.jaxrs" % "jackson-jaxrs-base" % "2.7.5",
+  "com.fasterxml.jackson.jaxrs" % "jackson-jaxrs-json-provider" % "2.7.5",
+  "com.fasterxml.jackson.module" % "jackson-module-jaxb-annotations" % "2.7.5",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.7.4",
+
+  "com.typesafe.akka" %% "akka-http-experimental" % "2.4.7",
+  "com.typesafe.akka" %% "akka-http-testkit" % "2.4.7" % "test",
+  "com.typesafe.akka" %% "akka-http-spray-json-experimental" % "2.4.7",
   "io.swagger" %% "swagger-scala-module" % "1.0.2",
   "io.swagger" % "swagger-core" % "1.5.9",
   "io.swagger" % "swagger-annotations" % "1.5.9",
   "io.swagger" % "swagger-models" % "1.5.9",
   "io.swagger" % "swagger-jaxrs" % "1.5.9",
   "org.scalatest" %% "scalatest" % "2.2.5" % "test",
-  "org.json4s" %% "json4s-jackson" % "3.2.11",
-  "org.json4s" %% "json4s-native" % "3.2.11",
+  "org.json4s" %% "json4s-jackson" % "3.4.0",
+  "org.json4s" %% "json4s-native" % "3.4.0",
   "joda-time" % "joda-time" % "2.8" % "test",
   "org.joda" % "joda-convert" % "1.7" % "test",
   "org.slf4j" % "slf4j-simple" % "1.7.7" % "test"

--- a/src/test/scala/com/github/swagger/akka/ApiReaderSpec.scala
+++ b/src/test/scala/com/github/swagger/akka/ApiReaderSpec.scala
@@ -191,7 +191,7 @@ class ApiReaderSpec
       val defMap = swagger.getDefinitions()
       "contain the dataType in the definitions" in {
         defMap should not be (null)
-        defMap should have size (2)
+        defMap should have size (4)
         val testModelDef = defMap.get("TestModel")
         testModelDef should not be (null)
         testModelDef.getProperties() should have size (11)

--- a/src/test/scala/com/github/swagger/akka/SwaggerModelConverterSpec.scala
+++ b/src/test/scala/com/github/swagger/akka/SwaggerModelConverterSpec.scala
@@ -100,7 +100,7 @@ class SwaggerModelConverterSpec
         // NOTE using stock swagger-scala-module at this point
         // will have this as an array instead of a string.
         // swagger-api/swagger-scala-module Pull Request #9 addresses this
-        value.getType() should equal ("string")
+        value.getType() should equal ("ref")
       }
     }
   }


### PR DESCRIPTION
- updating to latest akka lib 2.4.7
- updating json4s to 3.4.0
- *forcing* reference to jackson 2.7.5 (for now) because jsons 3.4.0 references jackson 2.7.1 which breaks backwards-compatibility to jackson 2.4.5 (which json4s 3.2.11 uses)