### PR TITLE
fixed: SwaggerHttpService route was affecting other custom routes aft…

### DIFF
--- a/src/main/scala/com/github/swagger/akka/SwaggerHttpService.scala
+++ b/src/main/scala/com/github/swagger/akka/SwaggerHttpService.scala
@@ -81,10 +81,11 @@ trait SwaggerHttpService extends Directives with SprayJsonSupport {
   
   def toJsonString(s: Swagger): String = Json.mapper().writeValueAsString(s)
   
-  val routes: Route = get {
+  lazy val routes: Route =
     path(removeInitialSlashIfNecessary(apiDocsPath) / "swagger.json") {
-      complete(toJsonString(swagger).parseJson.asJsObject)
+      get {
+        complete(toJsonString(swagger).parseJson.asJsObject)
+      }
     }
-  }
 
 }


### PR DESCRIPTION
…er composing with them. When some route was not matched akka did return 405, but should 404