### PR TITLE
Support object-based sources for swagger

### DIFF
--- a/src/main/scala/com/github/swagger/akka/SwaggerHttpService.scala
+++ b/src/main/scala/com/github/swagger/akka/SwaggerHttpService.scala
@@ -57,7 +57,7 @@ object SwaggerHttpService {
     if (typeSymbol.isModuleClass) {
       val idx = fullName.lastIndexOf('.')
       if (idx >= 0) {
-        val mangledName = s"${fullName.slice(0, idx)}$$${fullName.slice(idx+1, fullName.length)}$$"
+        val mangledName = s"${fullName.slice(0, idx)}.${fullName.slice(idx+1, fullName.length)}$$"
         mangledName
       } else fullName
     } else fullName

--- a/src/test/scala/com/github/swagger/akka/ApiReaderSpec.scala
+++ b/src/test/scala/com/github/swagger/akka/ApiReaderSpec.scala
@@ -41,7 +41,7 @@ class ApiReaderSpec
   val HOST = "www.example.com"
 
   val swaggerInfo = new Info().version(API_VERSION)
-
+private def objectType(objectClass: Class[_]) = runtimeMirror(objectClass.getClassLoader).classSymbol(objectClass).toType
 
   "The Reader object" when {
     "passed an api with no annotation" should {
@@ -347,5 +347,16 @@ class ApiReaderSpec
         resp200 should not be (null)
       }
     }
+
+    "passed an object as service" should {
+      val swaggerConfig = new Swagger().basePath(BASE_PATH).info(swaggerInfo)
+      val reader = new Reader(swaggerConfig, readerConfig)
+      "build the Swagger definition without errors" in {
+        noException should be thrownBy {
+          reader.read(toJavaTypeSet(Seq(objectType(TestApiWithObject.getClass))))
+        }
+      }
+    }
   }
+
 }

--- a/src/test/scala/com/github/swagger/akka/ApiReaderSpec.scala
+++ b/src/test/scala/com/github/swagger/akka/ApiReaderSpec.scala
@@ -357,6 +357,20 @@ private def objectType(objectClass: Class[_]) = runtimeMirror(objectClass.getCla
         }
       }
     }
+
+    "passed an object that does not extend an HttpService" should {
+      val swaggerConfig = new Swagger().basePath(BASE_PATH).info(swaggerInfo)
+      val reader = new Reader(swaggerConfig, readerConfig)
+      val swagger: Swagger = reader.read(toJavaTypeSet(Seq(objectType(TestApiWithObject.getClass))))
+      "build the Swagger definition anyway" in {
+        swagger.getPaths() should have size (1)
+
+        swagger.getPaths().get("/test") should not be (null)
+
+        val getOperation = swagger.getPaths().get("/test").getGet()
+        getOperation should not be (null)
+      }
+    }
   }
 
 }

--- a/src/test/scala/com/github/swagger/akka/samples/Apis.scala
+++ b/src/test/scala/com/github/swagger/akka/samples/Apis.scala
@@ -130,3 +130,8 @@ abstract class TestApiWithApiResponse {
   def testOperation
 }
 
+@Api(value = "/test")
+@Path("/test")
+object TestApiWithObject {
+
+}

--- a/src/test/scala/com/github/swagger/akka/samples/Apis.scala
+++ b/src/test/scala/com/github/swagger/akka/samples/Apis.scala
@@ -133,5 +133,6 @@ abstract class TestApiWithApiResponse {
 @Api(value = "/test")
 @Path("/test")
 object TestApiWithObject {
-
+  @ApiOperation(value = "testApiOperation", httpMethod = "GET")
+  def testOperation = {}
 }


### PR DESCRIPTION
A little fix to support objects to be sources of swagger api reader. 