### PR TITLE
0.9.0 to support scala 2.11 and 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ jdk:
   - oraclejdk8
 scala:
    - 2.11.8
+   - 2.12.1
 script:
   - sbt ++$TRAVIS_SCALA_VERSION coverage test coverageReport
 after_success:

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ The [swagger spec](http://swagger.io/specification/) is helpful for understandin
 The jars are hosted on [sonatype](https://oss.sonatype.org) and mirrored to Maven Central. Swagger-akka-http is built against scala 2.11. Snapshot releases are also hosted on sonatype. 
 
 ```sbt
-libraryDependencies += "com.github.swagger-akka-http" %% "swagger-akka-http" % "0.8.2"
+libraryDependencies += "com.github.swagger-akka-http" %% "swagger-akka-http" % "0.9.0"
 ```
-swagger-akka-http 0.8.2 is available in sonatype repository and it targets Akka Http 10.0.0.
+swagger-akka-http 0.9.0 is available in sonatype repository and it targets Akka Http 10.0.0. There are scala 2.11 and 2.12 compatible jars available.
+
+Swagger libraries depend heavily on [Jackson](http://wiki.fasterxml.com/JacksonHome). If you need to older versions of Jackson, consider using swagger-akka-http 0.8.2. It depends on Jackson 2.4.
 
 Scala 2.10 support for akka-http 2.0.3 requires swagger-akka-http 0.6.2.
-
-Scala 2.12 is supported in 0.9.0-SNAPSHOT. This snapshot requires some patches to the core swagger code.
 
 ## Examples
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,26 +4,28 @@ name := "swagger-akka-http"
 
 scalaVersion := "2.11.8"
 
-val swaggerVersion = "1.5.10"
-val akkaHttpVersion = "10.0.0"
+val swaggerVersion = "1.5.12"
+val akkaHttpVersion = "10.0.1"
+val jacksonVersion = "2.8.4"
 val slf4jVersion = "1.7.7"
 
 checksums in update := Nil
 
-EclipseKeys.withSource := true
+//EclipseKeys.withSource := true
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
   "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpVersion % "test",
   "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % "test",
-  "io.swagger" %% "swagger-scala-module" % "1.0.2",
   "io.swagger" % "swagger-core" % swaggerVersion,
   "io.swagger" % "swagger-annotations" % swaggerVersion,
   "io.swagger" % "swagger-models" % swaggerVersion,
   "io.swagger" % "swagger-jaxrs" % swaggerVersion,
   "org.slf4j" % "slf4j-api" % slf4jVersion,
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % jacksonVersion,
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "org.json4s" %% "json4s-native" % "3.4.2" % "test",
+  "org.json4s" %% "json4s-native" % "3.5.0" % "test",
   "joda-time" % "joda-time" % "2.8" % "test",
   "org.joda" % "joda-convert" % "1.7" % "test",
   "org.slf4j" % "slf4j-simple" % slf4jVersion % "test"

--- a/src/main/resources/META-INF/services/io.swagger.converter.ModelConverter
+++ b/src/main/resources/META-INF/services/io.swagger.converter.ModelConverter
@@ -1,0 +1,1 @@
+com.github.swagger.akka.SwaggerScalaModelConverter

--- a/src/main/scala/com/github/swagger/akka/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/com/github/swagger/akka/SwaggerScalaModelConverter.scala
@@ -1,0 +1,102 @@
+/*
+Copyright 2016 SmartBear Software, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.github.swagger.akka
+
+import java.lang.annotation.Annotation
+import java.lang.reflect.Type
+import java.util.Iterator
+
+import com.fasterxml.jackson.databind.`type`.ReferenceType
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import io.swagger.converter._
+import io.swagger.models.Model
+import io.swagger.models.properties._
+import io.swagger.util.{Json, PrimitiveType}
+
+object SwaggerScalaModelConverter {
+  Json.mapper().registerModule(new DefaultScalaModule())
+}
+
+class SwaggerScalaModelConverter extends ModelConverter {
+  SwaggerScalaModelConverter
+
+  override
+  def resolveProperty(`type`: Type, context: ModelConverterContext,
+    annotations: Array[Annotation] , chain: Iterator[ModelConverter]): Property = {
+    val javaType = Json.mapper().constructType(`type`)
+    val cls = javaType.getRawClass
+
+    if(cls != null) {
+      // handle scala enums
+      getEnumerationInstance(cls) match {
+        case Some(enumInstance) =>
+          if (enumInstance.values != null) {
+            val sp = new StringProperty()
+            for (v <- enumInstance.values)
+              sp._enum(v.toString)
+            return sp
+          }
+        case None =>
+          if (cls.isAssignableFrom(classOf[BigDecimal])) {
+            return PrimitiveType.DECIMAL.createProperty()
+          }
+      }
+    }
+
+    // Unbox scala options
+    val nextType = `type` match {
+        case rt: ReferenceType if isOption(cls) => rt.getContentType
+        case _ => `type`
+      }
+
+    if (chain.hasNext())
+      chain.next().resolveProperty(nextType, context, annotations, chain)
+    else
+      null
+    }
+
+  override
+  def resolve(`type`: Type, context: ModelConverterContext, chain: Iterator[ModelConverter]): Model = {
+    val javaType = Json.mapper().constructType(`type`)
+    getEnumerationInstance(javaType.getRawClass) match {
+      case Some(enumInstance) =>null // ignore scala enums
+      case None =>
+        if (chain.hasNext()) {
+          val next = chain.next()
+          next.resolve(`type`, context, chain)
+        }
+        else
+          null
+    }
+  }
+  private def getEnumerationInstance(cls: Class[_]): Option[Enumeration] =
+  {
+    if (cls.getFields.map(_.getName).contains("MODULE$"))
+    {
+      val javaUniverse = scala.reflect.runtime.universe
+      val m = javaUniverse.runtimeMirror(Thread.currentThread().getContextClassLoader)
+      val moduleMirror = m.reflectModule(m.staticModule(cls.getName))
+      moduleMirror.instance match
+      {
+        case enumInstance: Enumeration => Some(enumInstance)
+        case _ => None
+      }
+    }
+    else{
+      None
+    }
+  }
+
+  private def isOption(cls: Class[_]): Boolean = cls == classOf[scala.Option[_]]
+
+}

--- a/src/test/scala/com/github/swagger/akka/ApiReaderSpec.scala
+++ b/src/test/scala/com/github/swagger/akka/ApiReaderSpec.scala
@@ -29,7 +29,6 @@ import javax.ws.rs.Path
 import scala.reflect.runtime.universe
 import com.github.swagger.akka.samples._
 
-
 class ApiReaderSpec
     extends WordSpec
     with Matchers {
@@ -41,7 +40,9 @@ class ApiReaderSpec
   val HOST = "www.example.com"
 
   val swaggerInfo = new Info().version(API_VERSION)
-private def objectType(objectClass: Class[_]) = runtimeMirror(objectClass.getClassLoader).classSymbol(objectClass).toType
+
+  private def objectType(objectClass: Class[_]) =
+    runtimeMirror(objectClass.getClassLoader).classSymbol(objectClass).toType
 
   "The Reader object" when {
     "passed an api with no annotation" should {
@@ -261,7 +262,7 @@ private def objectType(objectClass: Class[_]) = runtimeMirror(objectClass.getCla
     }
 
     //@ApiOperation position is deprecated and ignored in Swagger 1.5.X
-	  "passed a service with operations defined by position" ignore {
+    "passed a service with operations defined by position" ignore {
       val swaggerConfig = new Swagger().basePath(BASE_PATH).info(swaggerInfo)
       val reader = new Reader(swaggerConfig, readerConfig)
       val swagger: Swagger = reader.read(toJavaTypeSet(Seq(typeOf[TestApiWithOperationPositions])))

--- a/src/test/scala/com/github/swagger/akka/SwaggerModelConverterSpec.scala
+++ b/src/test/scala/com/github/swagger/akka/SwaggerModelConverterSpec.scala
@@ -30,24 +30,24 @@ class SwaggerModelConverterSpec
   "The ModelConverter object" when {
     "passed an annotated scala class" should {
       "produce a Swagger Model" in {
-          val schemas = ModelConverters.getInstance().readAll(classOf[ModelBase])
-          val userSchema = schemas.get ("ModelBase")
-          userSchema.getDescription() should equal (ModelBaseDescription)
-          val name = userSchema.getProperties().get("name")
-          name.isInstanceOf[StringProperty] should be (true)
-          name.getDescription() should equal ("name123")
-        }
+        val schemas = ModelConverters.getInstance().readAll(classOf[ModelBase])
+        val userSchema = schemas.get ("ModelBase")
+        userSchema.getDescription() should equal (ModelBaseDescription)
+        val name = userSchema.getProperties().get("name")
+        name.isInstanceOf[StringProperty] should be (true)
+        name.getDescription() should equal ("name123")
+      }
       "include the base class details in the Swagger Model" in {
-          val schemas = ModelConverters.getInstance().readAll(classOf[ModelExtension])
-          val userSchema = schemas.get ("ModelExtension")
-          userSchema.getDescription() should equal (ModelExtensionDescription)
-          val name = userSchema.getProperties().get("name")
-          name.getDescription() should equal (NameDescription)
-          val date = userSchema.getProperties().get("date")
-          date.getDescription() should equal (EndDateDescription)
-        }
+        val schemas = ModelConverters.getInstance().readAll(classOf[ModelExtension])
+        val userSchema = schemas.get ("ModelExtension")
+        userSchema.getDescription() should equal (ModelExtensionDescription)
+        val name = userSchema.getProperties().get("name")
+        name.getDescription() should equal (NameDescription)
+        val date = userSchema.getProperties().get("date")
+        date.getDescription() should equal (EndDateDescription)
+      }
       //@ApiOperation position is deprecated and ignored in Swagger 1.5.X
-	    "order fields by position in the Swagger Model" ignore {
+      "order fields by position in the Swagger Model" ignore {
         val schemas = ModelConverters.getInstance().readAll(classOf[TestModelPositions])
         val userSchema = schemas.get ("TestModelPositions")
         userSchema should not be (null)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.3-SNAPSHOT"
+version in ThisBuild := "0.9.0-SNAPSHOT"


### PR DESCRIPTION
Temporarily inlining the code from io.swagger:swagger-scala-module until its 2.12 compatible release is done.