### PR TITLE
Fixed typo in README: "approrpiate" => "appropriate"

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The `SwaggerHttpService` is a trait extending Akka-Http's `HttpService`. It will
 
 The  `SwaggerHttpService` will contain a `routes` property you can concatenate along with your existing akka-http routes. This will expose an endpoint at `<baseUrl>/<specPath>/<resourcePath>` with the specified `apiVersion`, `swaggerVersion` and resource listing.
 
-The service requires a set of `apiTypes` and `modelTypes` you want to expose via Swagger. These types include the appropriate Swagger annotations for describing your api. The `SwaggerHttpService` will inspect these annotations and build the approrpiate Swagger response.
+The service requires a set of `apiTypes` and `modelTypes` you want to expose via Swagger. These types include the appropriate Swagger annotations for describing your api. The `SwaggerHttpService` will inspect these annotations and build the appropriate Swagger response.
 
 Here's an example `SwaggerHttpService` snippet which exposes [Wordnik's PetStore](http://petstore.swagger.io/) resources, `Pet`, `User` and `Store`. The routes property can be concatenated to your other route definitions:
 


### PR DESCRIPTION
Fixed typo in README: `approrpiate` => `appropriate`.