### PR TITLE
Allow to filter out scala boilerplate definitions

### DIFF
--- a/src/main/scala/com/github/swagger/akka/SwaggerHttpService.scala
+++ b/src/main/scala/com/github/swagger/akka/SwaggerHttpService.scala
@@ -59,6 +59,7 @@ trait SwaggerHttpService extends Directives {
   val securitySchemeDefinitions: Map[String, SecuritySchemeDefinition] = Map()
   val externalDocs: Option[ExternalDocs] = None
   val vendorExtensions: Map[String, Object] = Map.empty
+  val unwantedDefinitions: Seq[String] = Seq.empty
 
   def swaggerConfig: Swagger = {
     val modifiedPath = prependSlashIfNecessary(basePath)
@@ -77,8 +78,7 @@ trait SwaggerHttpService extends Directives {
 
   def generateSwaggerJson: String = {
     try {
-      val swagger: Swagger = reader.read(toJavaTypeSet(apiTypes).asJava)
-      Json.pretty().writeValueAsString(swagger)
+      Json.pretty().writeValueAsString(filteredSwagger)
     } catch {
       case NonFatal(t) => {
         logger.error("Issue with creating swagger.json", t)
@@ -89,14 +89,19 @@ trait SwaggerHttpService extends Directives {
 
   def generateSwaggerYaml: String = {
     try {
-      val swagger: Swagger = reader.read(toJavaTypeSet(apiTypes).asJava)
-      Yaml.pretty().writeValueAsString(swagger)
+      Yaml.pretty().writeValueAsString(filteredSwagger)
     } catch {
       case NonFatal(t) => {
         logger.error("Issue with creating swagger.yaml", t)
         throw t
       }
     }
+  }
+
+  private def filteredSwagger: Swagger = {
+    val swagger: Swagger = reader.read(toJavaTypeSet(apiTypes).asJava)
+    swagger.setDefinitions(swagger.getDefinitions.asScala.filterNot { case (modelName, _) => unwantedDefinitions.contains(modelName) }.asJava)
+    swagger
   }
 
   lazy val apiDocsBase = PathMatchers.separateOnSlashes(removeInitialSlashIfNecessary(apiDocsPath))

--- a/src/main/scala/com/github/swagger/akka/SwaggerHttpService.scala
+++ b/src/main/scala/com/github/swagger/akka/SwaggerHttpService.scala
@@ -100,7 +100,7 @@ trait SwaggerHttpService extends Directives {
 
   private def filteredSwagger: Swagger = {
     val swagger: Swagger = reader.read(toJavaTypeSet(apiTypes).asJava)
-    swagger.setDefinitions(swagger.getDefinitions.asScala.filterNot { case (modelName, _) => unwantedDefinitions.contains(modelName) }.asJava)
+    swagger.setDefinitions(swagger.getDefinitions.asScala.filterKeys(definitionName => !unwantedDefinitions.contains(definitionName)).asJava)
     swagger
   }
 

--- a/src/test/scala/com/github/swagger/akka/SwaggerHttpServiceSpec.scala
+++ b/src/test/scala/com/github/swagger/akka/SwaggerHttpServiceSpec.scala
@@ -1,11 +1,13 @@
 package com.github.swagger.akka
 
 import java.util
+import scala.collection.JavaConverters._
 import scala.reflect.runtime.universe.typeOf
 import scala.collection.immutable.ListMap
 import org.json4s._
 import org.json4s.native.JsonMethods._
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.yaml.snakeyaml.Yaml
 import com.github.swagger.akka.model._
 import com.github.swagger.akka.samples._
 import akka.http.scaladsl.model._
@@ -14,8 +16,6 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import io.swagger.models.{ExternalDocs, Scheme}
 import io.swagger.models.auth.BasicAuthDefinition
-import org.yaml.snakeyaml.Yaml
-import collection.JavaConverters._
 
 class SwaggerHttpServiceSpec
     extends WordSpec with Matchers with BeforeAndAfterAll with ScalatestRouteTest {

--- a/src/test/scala/com/github/swagger/akka/SwaggerHttpServiceSpec.scala
+++ b/src/test/scala/com/github/swagger/akka/SwaggerHttpServiceSpec.scala
@@ -1,5 +1,6 @@
 package com.github.swagger.akka
 
+import java.util
 import scala.reflect.runtime.universe.typeOf
 import scala.collection.immutable.ListMap
 import org.json4s._
@@ -13,6 +14,8 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import io.swagger.models.{ExternalDocs, Scheme}
 import io.swagger.models.auth.BasicAuthDefinition
+import org.yaml.snakeyaml.Yaml
+import collection.JavaConverters._
 
 class SwaggerHttpServiceSpec
     extends WordSpec with Matchers with BeforeAndAfterAll with ScalatestRouteTest {
@@ -82,6 +85,27 @@ class SwaggerHttpServiceSpec
           val response = parse(str)
           (response \ "swagger").extract[String] shouldEqual "2.0"
           (response \ "paths" \ "/dogs" \ "get" \ "operationId").extract[String] shouldEqual "getDogs"
+        }
+      }
+      "return correct definitions in swagger json" in {
+        val svc = new NestedService(system)
+
+        Get(s"/${svc.swaggerService.apiDocsPath}/swagger.json") ~> svc.swaggerService.routes ~> check {
+          handled shouldBe true
+          status.intValue shouldBe 200
+          val definitions = (parse(responseAs[String]) \ "definitions").values.asInstanceOf[Map[String, String]].keys
+          definitions shouldBe Set("ListReply")
+        }
+      }
+      "return correct definitions in swagger yaml" in {
+        val svc = new NestedService(system)
+
+        Get(s"/${svc.swaggerService.apiDocsPath}/swagger.yaml") ~> svc.swaggerService.routes ~> check {
+          handled shouldBe true
+          status.intValue shouldBe 200
+          val yaml = new Yaml().load(responseAs[String]).asInstanceOf[util.Map[String, Object]].asScala
+          val definitions = yaml.get("definitions").map(_.asInstanceOf[util.LinkedHashMap[String, String]].asScala.keys)
+          definitions shouldBe Some(Set("ListReply"))
         }
       }
     }

--- a/src/test/scala/com/github/swagger/akka/samples/DogsHttpService.scala
+++ b/src/test/scala/com/github/swagger/akka/samples/DogsHttpService.scala
@@ -17,18 +17,18 @@ package com.github.swagger.akka.samples
 
 import javax.ws.rs.Path
 
-import akka.actor.{ActorRefFactory, ActorSystem}
-import akka.http.scaladsl.model.ContentTypes.`application/json`
-import akka.http.scaladsl.model.HttpMethods.OPTIONS
-import akka.http.scaladsl.model.StatusCodes.OK
-import akka.http.scaladsl.model.headers.`Access-Control-Allow-Methods`
-import akka.http.scaladsl.model.{HttpEntity, HttpResponse}
-import akka.http.scaladsl.server.{Directives, Route}
+import scala.reflect.runtime.universe._
+
 import com.github.swagger.akka._
 import com.github.swagger.akka.model.{Contact, Info, License}
+
+import akka.actor.{ActorRefFactory, ActorSystem}
+import akka.http.scaladsl.model.ContentTypes.`application/json`
+import akka.http.scaladsl.model.StatusCodes.OK
+import akka.http.scaladsl.model.{HttpEntity, HttpResponse}
+import akka.http.scaladsl.server.{Directives, Route}
 import io.swagger.annotations._
 
-import scala.reflect.runtime.universe._
 
 case class Dog(breed: String)
 
@@ -80,8 +80,7 @@ class NestedService(system: ActorSystem) {self =>
     )
     @ApiResponses(Array(new ApiResponse(code = 200, message = "OK")))
     def optionsRoute: Route = (path("dogs") & options) {
-      complete(HttpResponse(OK, entity = HttpEntity.empty(`application/json`),
-        headers = List(`Access-Control-Allow-Methods`(OPTIONS))))
+      complete(HttpResponse(OK, entity = HttpEntity.empty(`application/json`)))
     }
   }
 }


### PR DESCRIPTION
Way around [issue-45](https://github.com/swagger-akka-http/swagger-akka-http/issues/45).