### PR TITLE
Handle empty definitions gracefully

### DIFF
--- a/src/main/scala/com/github/swagger/akka/SwaggerHttpService.scala
+++ b/src/main/scala/com/github/swagger/akka/SwaggerHttpService.scala
@@ -21,7 +21,7 @@ import akka.http.scaladsl.model.{HttpEntity, MediaTypes}
 import akka.http.scaladsl.server.{Directives, PathMatchers, Route}
 import io.swagger.jaxrs.Reader
 import io.swagger.jaxrs.config.DefaultReaderConfig
-import io.swagger.models.{ExternalDocs, Scheme, Swagger}
+import io.swagger.models.{ExternalDocs, Model, Scheme, Swagger}
 import io.swagger.models.auth.SecuritySchemeDefinition
 import io.swagger.util.{Json, Yaml}
 import org.apache.commons.lang3.StringUtils
@@ -91,7 +91,7 @@ trait SwaggerHttpService extends Directives {
 
   private def filteredSwagger: Swagger = {
     val swagger: Swagger = reader.read(apiClasses.asJava)
-    swagger.setDefinitions(swagger.getDefinitions.asScala.filterKeys(definitionName => !unwantedDefinitions.contains(definitionName)).asJava)
+    swagger.setDefinitions(Option(swagger.getDefinitions).map(_.asScala).getOrElse(Map.empty[String, Model]).filterKeys(definitionName => !unwantedDefinitions.contains(definitionName)).asJava)
     swagger
   }
 

--- a/src/test/scala/com/github/swagger/akka/SwaggerHttpServiceSpec.scala
+++ b/src/test/scala/com/github/swagger/akka/SwaggerHttpServiceSpec.scala
@@ -215,5 +215,21 @@ class SwaggerHttpServiceSpec
       }
     }
 
+    "not defining API classes" should {
+      "return an empty set of definitions" in {
+        val swaggerService = new SwaggerHttpService {
+          override val apiClasses = Set.empty[Class[_]]
+        }
+
+        Get(s"/${swaggerService.apiDocsPath}/swagger.json") ~> swaggerService.routes ~> check {
+          handled shouldBe true
+          contentType shouldBe ContentTypes.`application/json`
+          val str = responseAs[String]
+          val response = parse(str)
+
+          (response \ "definitions").values.asInstanceOf[Map[String, String]] shouldEqual(Map.empty)
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
If the Map of definitions is empty, the underlying model will return a null pointer, which explodes the new `filteredSwagger` function on the `asScala` call.

This handles the case more gracefully