### PR TITLE
Allow multiple schemes to be defined

### DIFF
--- a/src/main/scala/com/github/swagger/akka/SwaggerHttpService.scala
+++ b/src/main/scala/com/github/swagger/akka/SwaggerHttpService.scala
@@ -46,7 +46,7 @@ trait SwaggerGenerator {
   def basePath: String = "/"
   def apiDocsPath: String = "api-docs"
   def info: Info = Info()
-  def scheme: Scheme = Scheme.HTTP
+  def schemes: List[Scheme] = List(Scheme.HTTP)
   def securitySchemeDefinitions: Map[String, SecuritySchemeDefinition] = Map.empty
   def externalDocs: Option[ExternalDocs] = None
   def vendorExtensions: Map[String, Object] = Map.empty
@@ -54,7 +54,7 @@ trait SwaggerGenerator {
 
   def swaggerConfig: Swagger = {
     val modifiedPath = prependSlashIfNecessary(basePath)
-    val swagger = new Swagger().basePath(modifiedPath).info(info).scheme(scheme)
+    val swagger = new Swagger().basePath(modifiedPath).info(info).schemes(schemes.asJava)
     if(StringUtils.isNotBlank(host)) swagger.host(host)
     swagger.setSecurityDefinitions(securitySchemeDefinitions.asJava)
     swagger.vendorExtensions(vendorExtensions.asJava)

--- a/src/main/scala/com/github/swagger/akka/javadsl/SwaggerGenerator.scala
+++ b/src/main/scala/com/github/swagger/akka/javadsl/SwaggerGenerator.scala
@@ -13,7 +13,7 @@ trait SwaggerGenerator {
   def basePath: String = "/"
   def apiDocsPath: String = "api-docs"
   def info: Info = new Info()
-  def scheme: Scheme = Scheme.HTTP
+  def schemes: List[Scheme] = List(Scheme.HTTP)
   def securitySchemeDefinitions: util.Map[String, SecuritySchemeDefinition] = util.Collections.emptyMap()
   def externalDocs: util.Optional[ExternalDocs] = util.Optional.empty()
   def vendorExtensions: util.Map[String, Object] = util.Collections.emptyMap()
@@ -32,7 +32,7 @@ private class Converter(javaGenerator: SwaggerGenerator) extends com.github.swag
   override def basePath: String = javaGenerator.basePath
   override def apiDocsPath: String = javaGenerator.apiDocsPath
   override def info: com.github.swagger.akka.model.Info = javaGenerator.info
-  override def scheme: Scheme = javaGenerator.scheme
+  override def schemes: List[Scheme] = javaGenerator.schemes
   override def securitySchemeDefinitions: Map[String, SecuritySchemeDefinition] = javaGenerator.securitySchemeDefinitions.asScala.toMap
   override def externalDocs: Option[ExternalDocs] = javaGenerator.externalDocs.asScala
   override def vendorExtensions: Map[String, Object] = javaGenerator.vendorExtensions.asScala.toMap

--- a/src/test/scala/com/github/swagger/akka/ApiReaderSpec.scala
+++ b/src/test/scala/com/github/swagger/akka/ApiReaderSpec.scala
@@ -176,6 +176,19 @@ class ApiReaderSpec
       }
     }
 
+    "passed a properly annotated HttpService with multiple schemes" should {
+      val swaggerConfig = new Swagger()
+        .host(HOST)
+        .schemes(List(Scheme.HTTP, Scheme.HTTPS).asJava)
+        .basePath(BASE_PATH).info(swaggerInfo)
+      val reader = new Reader(swaggerConfig, readerConfig)
+      val swagger: Swagger = reader.read(Set[Class[_]](classOf[DictHttpService]).asJava)
+
+      "set the schemes" in {
+        swagger.getSchemes() shouldBe List(Scheme.HTTP, Scheme.HTTPS).asJava
+      }
+    }
+
     "passed a service referencing a dataType" should {
       val swaggerConfig = new Swagger().basePath(BASE_PATH).info(swaggerInfo)
       val reader = new Reader(swaggerConfig, readerConfig)

--- a/src/test/scala/com/github/swagger/akka/SwaggerHttpServiceSpec.scala
+++ b/src/test/scala/com/github/swagger/akka/SwaggerHttpServiceSpec.scala
@@ -30,7 +30,7 @@ class SwaggerHttpServiceSpec
     override val apiClasses: Set[Class[_]] = Set(classOf[PetHttpService], classOf[UserHttpService])
     override val basePath = "api"
     override val apiDocsPath = "api-doc"
-    override val scheme = Scheme.HTTPS
+    override val schemes = List(Scheme.HTTPS)
     override val host = "some.domain.com:12345"
     override val info = Info(description = "desc1",
                    version = "v1.0",
@@ -228,6 +228,22 @@ class SwaggerHttpServiceSpec
         definitions should have size 4
         val smap = swaggerService.asScala[String, Model](definitions)
         smap should contain theSameElementsAs definitions.asScala
+      }
+    }
+
+    "defining multiple schemes" should {
+      val swaggerService = new SwaggerHttpService {
+        override val apiClasses: Set[Class[_]] = Set(classOf[UserHttpService])
+        override val schemes: List[Scheme] = List(Scheme.HTTPS, Scheme.HTTP)
+      }
+      "return all schemes" in {
+        Get(s"/${swaggerService.apiDocsPath}/swagger.json") ~> swaggerService.routes ~> check {
+          handled shouldBe true
+          contentType shouldBe ContentTypes.`application/json`
+          val str = responseAs[String]
+          val response = parse(str)
+          (response \ "schemes").extract[List[String]] shouldEqual List("https", "http")
+        }
       }
     }
   }

--- a/src/test/scala/com/github/swagger/akka/javadsl/SwaggerGeneratorSpec.scala
+++ b/src/test/scala/com/github/swagger/akka/javadsl/SwaggerGeneratorSpec.scala
@@ -33,7 +33,7 @@ class SwaggerGeneratorSpec extends WordSpec with Matchers {
         override def basePath: String = "/base"
         override def apiDocsPath: String = "docs"
         override def info: Info = testInfo
-        override def scheme: Scheme = Scheme.HTTPS
+        override def schemes: List[Scheme] = List(Scheme.HTTPS)
         override def securitySchemeDefinitions: util.Map[String, SecuritySchemeDefinition] = {
           val jmap = new util.HashMap[String, SecuritySchemeDefinition]()
           jmap.put("basic", securitySchemeDefinition)
@@ -53,7 +53,7 @@ class SwaggerGeneratorSpec extends WordSpec with Matchers {
       generator.converter.apiDocsPath shouldEqual generator.apiDocsPath
       import com.github.swagger.akka.model.scala2swagger
       scala2swagger(generator.converter.info) shouldEqual testInfo
-      generator.converter.scheme shouldEqual generator.scheme
+      generator.converter.schemes shouldEqual generator.schemes
       generator.converter.securitySchemeDefinitions.asJava shouldEqual generator.securitySchemeDefinitions
       generator.converter.externalDocs.get shouldEqual generator.externalDocs.get()
       generator.converter.vendorExtensions.asJava shouldEqual generator.vendorExtensions

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.10.2-SNAPSHOT"
+version in ThisBuild := "0.11.0-SNAPSHOT"


### PR DESCRIPTION
Hi. Today it's not possible to set multiple schemes in `SwaggerHttpService`, which is allowed in Swagger core. This PR changes that by replacing the `scheme` property with a `schemes` property which takes a List of schemes.