### PR TITLE
Add HTTPS support to SwaggerHttpService default schemes

### DIFF
--- a/src/main/scala/com/github/swagger/akka/SwaggerHttpService.scala
+++ b/src/main/scala/com/github/swagger/akka/SwaggerHttpService.scala
@@ -47,7 +47,7 @@ trait SwaggerGenerator {
   def basePath: String = "/"
   def apiDocsPath: String = "api-docs"
   def info: Info = Info()
-  def schemes: List[Scheme] = List(Scheme.HTTP)
+  def schemes: List[Scheme] = List(Scheme.HTTP, Scheme.HTTPS)
   def securitySchemeDefinitions: Map[String, SecuritySchemeDefinition] = Map.empty
   def externalDocs: Option[ExternalDocs] = None
   def vendorExtensions: Map[String, Object] = Map.empty

--- a/src/test/scala/com/github/swagger/akka/MinimalSwaggerHttpServiceSpec.scala
+++ b/src/test/scala/com/github/swagger/akka/MinimalSwaggerHttpServiceSpec.scala
@@ -34,7 +34,7 @@ class MinimalSwaggerHttpServiceSpec
           val response = parse(str)
           (response \ "swagger").extract[String] shouldEqual "2.0"
           (response \ "host") shouldBe JNothing
-          (response \ "schemes").extract[List[String]] shouldEqual List("http")
+          (response \ "schemes").extract[List[String]] shouldEqual List("http", "https")
           (response \ "basePath").extract[String] shouldEqual s"${swaggerService.basePath}"
           (response \ "externalDocs").extract[Option[Map[String, String]]] shouldEqual None
           (response \ "securityDefinitions").extract[Map[String, String]] shouldEqual Map()


### PR DESCRIPTION
Add HTTPS support to default schemes, as it's very common to have HTTPS support requirement in a production environment. Developers can get this support out-of-box. No need explicitly override schemes.