### PR TITLE
do not set immutable java collections on swagger apis

### DIFF
--- a/src/test/scala/com/github/swagger/akka/SwaggerHttpServiceSpec.scala
+++ b/src/test/scala/com/github/swagger/akka/SwaggerHttpServiceSpec.scala
@@ -54,7 +54,7 @@ class SwaggerHttpServiceSpec
           val response = parse(str)
           (response \ "swagger").extract[String] shouldEqual "2.0"
           (response \ "host").extract[String] shouldEqual swaggerService.host
-          (response \ "schemes").extract[List[String]] shouldEqual List("https")
+          (response \ "schemes").extract[Set[String]] shouldEqual Set("http", "https")
           (response \ "basePath").extract[String] shouldEqual s"/${swaggerService.basePath}"
           val ed = swaggerService.externalDocs.getOrElse(throw new IllegalArgumentException("missing external docs"))
           (response \ "externalDocs").extract[Map[String, String]] shouldEqual Map(
@@ -228,8 +228,21 @@ class SwaggerHttpServiceSpec
           contentType shouldBe ContentTypes.`application/json`
           val str = responseAs[String]
           val response = parse(str)
-          (response \ "schemes").extract[List[String]] shouldEqual List("https", "http")
+          (response \ "schemes").extract[Set[String]] shouldEqual Set("https", "http")
         }
+      }
+    }
+
+    "conversion of scala collections to java" should {
+      "return mutable list" in {
+        val jlist = swaggerService.asJavaMutableList(List("http"))
+        jlist.add("extra")
+        jlist.asScala.toSet shouldEqual Set("http", "extra")
+      }
+      "return mutable map" in {
+        val jmap= swaggerService.asJavaMutableMap(Map("scheme" -> "http"))
+        jmap.put("extraKey", "extraValue")
+        jmap.asScala.toMap shouldEqual Map(("scheme" -> "http"), ("extraKey" -> "extraValue"))
       }
     }
   }

--- a/src/test/scala/com/github/swagger/akka/samples/DictHttpService.scala
+++ b/src/test/scala/com/github/swagger/akka/samples/DictHttpService.scala
@@ -1,23 +1,21 @@
 package com.github.swagger.akka.samples
 
-import io.swagger.annotations._
 import javax.ws.rs.Path
-import spray.json._
+
 import akka.http.scaladsl.server.Directives
-import akka.http.scaladsl.unmarshalling._
 import akka.stream.ActorMaterializer
 import akka.actor.ActorSystem
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.marshalling.ToResponseMarshallable.apply
 import akka.http.scaladsl.server.Directive.addByNameNullaryApply
 import akka.http.scaladsl.server.Directive.addDirectiveApply
+import io.swagger.annotations._
+import io.swagger.annotations.SwaggerDefinition.Scheme
 
 @Api(value = "/dict", description = "This is a dictionary api.")
 @Path("/dict")
 trait DictHttpService
     extends Directives
     with ModelFormats {
-  import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
   implicit val actorSystem = ActorSystem("mysystem")
   implicit val materializer = ActorMaterializer()
 

--- a/src/test/scala/com/github/swagger/akka/samples/UserHttpService.scala
+++ b/src/test/scala/com/github/swagger/akka/samples/UserHttpService.scala
@@ -15,22 +15,22 @@
  */
 package com.github.swagger.akka.samples
 
-import io.swagger.annotations._
 import javax.ws.rs.Path
-import akka.http.scaladsl.server.Directives
-import akka.http.scaladsl.server.Directives._
-import spray.json.DefaultJsonProtocol
-import akka.stream.ActorMaterializer
+
 import akka.actor.ActorSystem
+import akka.http.scaladsl.server.Directives
+import akka.stream.ActorMaterializer
+import io.swagger.annotations.SwaggerDefinition.Scheme
+import io.swagger.annotations._
 
 @Api(value = "/user", description = "Operations about users.", produces = "application/json")
 @Path("/user")
+@SwaggerDefinition(schemes = Array(Scheme.HTTP))
 trait UserHttpService
     extends Directives
     with ModelFormats {
   implicit val actorSystem = ActorSystem("mysystem")
   implicit val materializer = ActorMaterializer()
-  import actorSystem.dispatcher
   @ApiOperation(value = "Updated user", notes = "This can only be done by the logged in user.", nickname = "updateUser", httpMethod = "PUT")
   @ApiImplicitParams(Array(
     new ApiImplicitParam(name = "username", value = "ID of user that needs to be updated", required = true, dataType = "string", paramType = "path"),


### PR DESCRIPTION
https://github.com/swagger-akka-http/swagger-akka-http/issues/60

Swagger Core does not clone the java collections that we set. Then, if you call add methods, the underlying collections can't be immutable.