### PR TITLE
Added securitySchemes

### DIFF
--- a/src/main/scala/com/github/swagger/akka/SwaggerHttpService.scala
+++ b/src/main/scala/com/github/swagger/akka/SwaggerHttpService.scala
@@ -21,7 +21,7 @@ import io.swagger.v3.jaxrs2.Reader
 import io.swagger.v3.oas.integration.SwaggerConfiguration
 import io.swagger.v3.oas.models.security.{SecurityRequirement, SecurityScheme}
 import io.swagger.v3.oas.models.servers.Server
-import io.swagger.v3.oas.models.{ExternalDocumentation, OpenAPI}
+import io.swagger.v3.oas.models.{Components, ExternalDocumentation, OpenAPI}
 import org.apache.commons.lang3.StringUtils
 import org.slf4j.LoggerFactory
 
@@ -48,6 +48,7 @@ trait SwaggerGenerator {
   def basePath: String = "/"
   def apiDocsPath: String = "api-docs"
   def info: Info = Info()
+  def components: Option[Components] = None
   def schemes: List[String] = List("http")
   def security: List[SecurityRequirement] = List()
   def securitySchemes: Map[String, SecurityScheme] = Map.empty
@@ -59,6 +60,7 @@ trait SwaggerGenerator {
     val modifiedPath = prependSlashIfNecessary(basePath)
     val swagger = new OpenAPI()
     swagger.setInfo(info)
+    components.foreach { c => swagger.setComponents(c) }
 
     //.basePath(modifiedPath)
     if(StringUtils.isNotBlank(host)) {

--- a/src/main/scala/com/github/swagger/akka/SwaggerHttpService.scala
+++ b/src/main/scala/com/github/swagger/akka/SwaggerHttpService.scala
@@ -19,6 +19,7 @@ import com.github.swagger.akka.model.{Info, asScala}
 import io.swagger.v3.core.util.{Json, Yaml}
 import io.swagger.v3.jaxrs2.Reader
 import io.swagger.v3.oas.integration.SwaggerConfiguration
+import io.swagger.v3.oas.models.security.{SecurityRequirement, SecurityScheme}
 import io.swagger.v3.oas.models.servers.Server
 import io.swagger.v3.oas.models.{ExternalDocumentation, OpenAPI}
 import org.apache.commons.lang3.StringUtils
@@ -48,7 +49,8 @@ trait SwaggerGenerator {
   def apiDocsPath: String = "api-docs"
   def info: Info = Info()
   def schemes: List[String] = List("http")
-  //def securitySchemeDefinitions: Map[String, SecuritySchemeDefinition] = Map.empty
+  def security: List[SecurityRequirement] = List()
+  def securitySchemes: Map[String, SecurityScheme] = Map.empty
   def externalDocs: Option[ExternalDocumentation] = None
   def vendorExtensions: Map[String, Object] = Map.empty
   def unwantedDefinitions: Seq[String] = Seq.empty
@@ -57,14 +59,17 @@ trait SwaggerGenerator {
     val modifiedPath = prependSlashIfNecessary(basePath)
     val swagger = new OpenAPI()
     swagger.setInfo(info)
+
     //.basePath(modifiedPath)
     if(StringUtils.isNotBlank(host)) {
       schemes.foreach { scheme =>
         swagger.addServersItem(new Server().url(s"${scheme.toLowerCase}://${host}"))
       }
     }
-    //swagger.setSecurityDefinitions(asJavaMutableMap(securitySchemeDefinitions))
+    securitySchemes.foreach { case (k: String, v: SecurityScheme) => swagger.schemaRequirement(k, v) }
+    swagger.setSecurity(asJavaMutableList(security))
     swagger.extensions(asJavaMutableMap(vendorExtensions))
+
     externalDocs match {
       case Some(ed) => swagger.setExternalDocs(ed)
       case None => swagger

--- a/src/main/scala/com/github/swagger/akka/javadsl/SwaggerGenerator.scala
+++ b/src/main/scala/com/github/swagger/akka/javadsl/SwaggerGenerator.scala
@@ -2,9 +2,10 @@ package com.github.swagger.akka.javadsl
 
 import java.util
 
-import io.swagger.v3.oas.models.ExternalDocumentation
+import io.swagger.v3.oas.models.{Components, ExternalDocumentation}
 import com.github.swagger.akka.model.asScala
 import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityScheme
 
 trait SwaggerGenerator {
   def apiClasses: util.Set[Class[_]]
@@ -13,7 +14,7 @@ trait SwaggerGenerator {
   def apiDocsPath: String = "api-docs"
   def info: Info = new Info()
   //def schemes: util.List[Scheme] = List(Scheme.HTTP).asJava
-  //def securitySchemeDefinitions: util.Map[String, SecuritySchemeDefinition] = util.Collections.emptyMap()
+  def securitySchemes: util.Map[String, SecurityScheme] = util.Collections.emptyMap()
   def externalDocs: util.Optional[ExternalDocumentation] = util.Optional.empty()
   def vendorExtensions: util.Map[String, Object] = util.Collections.emptyMap()
   def unwantedDefinitions: util.List[String] = util.Collections.emptyList()
@@ -32,7 +33,7 @@ private class Converter(javaGenerator: SwaggerGenerator) extends com.github.swag
   override def apiDocsPath: String = javaGenerator.apiDocsPath
   override def info: com.github.swagger.akka.model.Info = javaGenerator.info
   //override def schemes: List[Scheme] = asScala(javaGenerator.schemes)
-  //override def securitySchemeDefinitions: Map[String, SecuritySchemeDefinition] = asScala(javaGenerator.securitySchemeDefinitions)
+  override def securitySchemes: Map[String, SecurityScheme] = asScala(javaGenerator.securitySchemes)
   override def externalDocs: Option[ExternalDocumentation] = asScala(javaGenerator.externalDocs)
   override def vendorExtensions: Map[String, Object] = asScala(javaGenerator.vendorExtensions)
   override def unwantedDefinitions: Seq[String] = asScala(javaGenerator.unwantedDefinitions)


### PR DESCRIPTION
Adding SecurityScheme (previously securitySchemeDefinitions) - including test with bearer token configuration

Change will add the securitySchemes snippet with (for example) the bearer configuration. Any OpenAPI config can be used.
 
```
  "components" : {
  ...
    "securitySchemes" : {
      "bearerAuth" : {
        "type" : "http",
        "description" : "...",
        "scheme" : "bearer",
        "bearerFormat" : "JWT"
      }
    }
```