### PR TITLE
Align version of java8-compat with that of Akka.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,15 +12,11 @@ val scala213 = "2.13.6"
 ThisBuild / scalaVersion := scala213
 ThisBuild / crossScalaVersions := Seq(scala213, "2.12.15")
 
-// NOTE: Once akka updates to 1.0.0 of scala-java8-compat, remove this
-ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-java8-compat" % "always"
-
 update / checksums := Nil
 
 //resolvers += Resolver.sonatypeRepo("snapshots")
 
 libraryDependencies ++= Seq(
-  "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.0",
   "com.typesafe.akka" %% "akka-stream" % akkaVersion,
   "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
@@ -41,6 +37,16 @@ libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "2.2.1" % Test,
   "org.slf4j" % "slf4j-simple" % slf4jVersion % Test
 )
+
+// While not ideal, Akka 2.12 is still on 0.8.0 so to align with them we'll
+// stick on 0.8.0 for 2.12 only. This will ensure that users are aligned and
+// dno't have to add in hacks to avoid the early-semver mismatch that comes if
+// you try to include both 1.0.0 and 0.8.0 since it can't safely evict in that
+// case.
+libraryDependencies += CrossVersion.partialVersion(scalaVersion.value).map {
+  case ((2, 12)) => "org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0"
+  case _ => "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.0"
+}
 
 Test / testOptions += Tests.Argument("-oD")
 


### PR DESCRIPTION
Alright, so I think this might be the best of both worlds. Seeing that we want to update for 2.13 users, but also want to stay in line with Akka for 2.12 users. This will ensure that no users have to do the `libraryDependencySchemes` hack like we had in here before. For 2.12 users, they'll continue to get 0.8.0 just like Akka provides, and for 2.13 users, they'll get the 1.0.0, just like Akka. This should address the concerns you had with the previous solution.